### PR TITLE
Fixing Node 20 deprecation warning

### DIFF
--- a/actions/deploy-via-ftp/action.yml
+++ b/actions/deploy-via-ftp/action.yml
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Check out the Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Composer Dependencies if required
       if: ${{inputs.composer == 'true' }}

--- a/actions/deploy-via-rsync/action.yml
+++ b/actions/deploy-via-rsync/action.yml
@@ -64,7 +64,7 @@ runs:
   using: "composite"
   steps:
     - name: Check out the Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Composer Dependencies if required
       if: ${{inputs.composer == 'true' }}

--- a/actions/verify-branch-is-up-to-date/action.yml
+++ b/actions/verify-branch-is-up-to-date/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Check if branch contains main


### PR DESCRIPTION
Updates composite GitHub Actions to use actions/checkout@v4 to address Node 20 runtime deprecation warnings associated with actions/checkout@v3.

Changes:

Bump actions/checkout from @v3 to @v4 in the “verify branch is up to date” composite action.
Bump actions/checkout from @v3 to @v4 in the rsync deploy composite action.
Bump actions/checkout from @v3 to @v4 in the FTP deploy composite action.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213708775954088