### PR TITLE
Update Node version to fix Node 20 deprecation warnings (#8)

### DIFF
--- a/actions/deploy-via-ftp/action.yml
+++ b/actions/deploy-via-ftp/action.yml
@@ -52,7 +52,7 @@ runs:
         
     - name: Install Node Dependencies if required
       if: ${{inputs.npm == 'true' }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node_version || matrix.node }}
 

--- a/actions/deploy-via-rsync/action.yml
+++ b/actions/deploy-via-rsync/action.yml
@@ -76,7 +76,7 @@ runs:
         
     - name: Install Node Dependencies if required
       if: ${{inputs.npm == 'true' }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node_version || matrix.node }}
 


### PR DESCRIPTION
This PR updates the composite deployment actions’ Node setup step to a newer actions/setup-node major version, intended to address Node runtime deprecation warnings in GitHub Actions.